### PR TITLE
chore(open-api-patcher): remove missed /api-docs path when using cors

### DIFF
--- a/functions/src/api-docs.lambda.ts
+++ b/functions/src/api-docs.lambda.ts
@@ -4,7 +4,7 @@ import { OpenApiSpecPatcher } from "./open-api-spec-patcher";
 
 let apiGateway: APIGateway;
 
-const patcher = new OpenApiSpecPatcher({ pathsToRemove: ["/api-docs.json", "/api-docs/{proxy+}"] });
+const patcher = new OpenApiSpecPatcher({ pathsToRemove: ["/api-docs.json", "/api-docs/{proxy+}", "/api-docs"] });
 
 export async function handler(request: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   apiGateway = new APIGateway();

--- a/test/__snapshots__/swagger-ui.test.ts.snap
+++ b/test/__snapshots__/swagger-ui.test.ts.snap
@@ -483,7 +483,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c462545edc02a8dc26b4f3725a0c03c76b994c04959d06023b4a4262851fa1db.zip",
+          "S3Key": "b3dc14ec8ebbe09415ac5c0df9f37b9e73b33350dae0d51084f73a8c26669a69.zip",
         },
         "Description": "functions/src/api-docs.lambda.ts",
         "Environment": Object {


### PR DESCRIPTION
Fixes #

When testing 0.0.151 on a real deployment, i saw that one trace is still in the export when using certain global cors settings for the ApiGateway.

Status quo on latest: 
```json
{"openapi":"3.0.1","info":{"title":"Default - Example RAD RestAPI","version":"2022-11-26T08:35:47Z"},"servers":[{"url":"https://q0f5v6zml3.execute-api.eu-west-1.amazonaws.com/{basePath}","variables":{"basePath":{"default":"v1"}}}],"paths":{"/public":{"options":{"responses":{"204":{"description":"204 response","headers":{"Access-Control-Allow-Origin":{"schema":{"type":"string"}},"Access-Control-Allow-Methods":{"schema":{"type":"string"}},"Access-Control-Allow-Headers":{"schema":{"type":"string"}}},"content":{}}}}},"/public/public":{"get":{"responses":{"200":{"description":"200 response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HelloWorldResponseModel"}}}}}},"options":{"responses":{"204":{"description":"204 response","headers":{"Access-Control-Allow-Origin":{"schema":{"type":"string"}},"Access-Control-Allow-Methods":{"schema":{"type":"string"}},"Access-Control-Allow-Headers":{"schema":{"type":"string"}}},"content":{}}}}},"/api-docs":{"options":{"responses":{"204":{"description":"204 response","headers":{"Access-Control-Allow-Origin":{"schema":{"type":"string"}},"Access-Control-Allow-Methods":{"schema":{"type":"string"}},"Access-Control-Allow-Headers":{"schema":{"type":"string"}}},"content":{}}}}},"/":{"options":{"responses":{"204":{"description":"204 response","headers":{"Access-Control-Allow-Origin":{"schema":{"type":"string"}},"Access-Control-Allow-Methods":{"schema":{"type":"string"}},"Access-Control-Allow-Headers":{"schema":{"type":"string"}}},"content":{}}}}}},"components":{"schemas":{"HelloWorldResponseModel":{"title":"HelloWorldResponse","type":"object","properties":{"isError":{"type":"boolean"},"message":{"type":"string"}},"description":""}}}}
```

PR removes path: `/api-docs`

However works like charm thanks again for helping me out here to 💄 the swagger.ui 🙇 

Cheers 🍻 